### PR TITLE
06/08/2025 - Removed Toggle Key Combo

### DIFF
--- a/assets/js/keyboard-shortcuts.js
+++ b/assets/js/keyboard-shortcuts.js
@@ -78,12 +78,7 @@ class KeyboardShortcutManager {
             window.MarkTideUndoRedo.redoAction();
           }
           break;
-        case 'S':
-          e.preventDefault();
-          if (window.MarkTideScrollSync) {
-            window.MarkTideScrollSync.toggleSyncScrolling();
-          }
-          break;
+
         case 'Backspace':
           e.preventDefault();
           this.deleteToLineStart();


### PR DESCRIPTION
Remove: Ctrl+Shift+S keyboard shortcut to which toggles Sync This shortcut was not used by most, and also caused the built-in browser screenshot combo to not work.